### PR TITLE
NetCDF4-compatible diagnostic testing

### DIFF
--- a/tools/tests/experiment.py
+++ b/tools/tests/experiment.py
@@ -5,7 +5,6 @@ import sys
 import os
 import re
 import shlex
-import string
 import subprocess as sp
 import run_config as rc
 from model import Model
@@ -33,7 +32,7 @@ class Diagnostic:
 
 
 # Unfinished diagnostics are those which have been registered but have not been
-# implemented, so no post_data called. This list should to be updated as the
+# implemented, so no post_data called. This list should be updated as the
 # diags are completed.
 _unfinished_diags = [('ocean_model', 'uml_restrat'),
                      ('ocean_model', 'vml_restrat'),
@@ -63,7 +62,7 @@ def exp_id_from_path(path):
     path = os.path.normpath(path)
     path = path.replace(_mom_examples_path, '')
     # Remove possible '/' from front and back.
-    return string.strip(path, '/')
+    return path.strip('/')
 
 class Experiment:
 


### PR DESCRIPTION
Here's the small change I made to the hashing done in `test_checksums()`. I expect we need to:
- [ ] Use `NETCDF=4` for builds now
- [ ] Commit a new `diag_checksums.txt` (I haven't yet generated this with a `DEBUG` GNU build -- it'd be interesting to see if this is actually reproducible across our machines)
